### PR TITLE
Improve CI 

### DIFF
--- a/.github/workflows/parameter-file-validation.yml
+++ b/.github/workflows/parameter-file-validation.yml
@@ -33,7 +33,7 @@ jobs:
               echo "Testing parameter $file"
               # use schema from current branch
               # (as this branch might have introduced schema changes)
-              CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+              CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
               sed -i "" "s/main/$CURRENT_BRANCH/" "$file"
               cat "$file"
               simtools-validate-file-using-schema \

--- a/.github/workflows/parameter-file-validation.yml
+++ b/.github/workflows/parameter-file-validation.yml
@@ -24,6 +24,15 @@ jobs:
         run: |
           microdnf install -y findutils
 
+      - name: Current branch
+        run: |
+          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+            echo "CURRENT_BRANCH=${GITHUB_HEAD_REF}" >> "$GITHUB_ENV"
+          else
+            echo "CURRENT_BRANCH=${GITHUB_REF#refs/heads/}" >> "$GITHUB_ENV"
+          fi
+          echo "Current branch $CURRENT_BRANCH"
+
       - name: Parameter file validation.
         run: |
           for model in "verified_model" "validated_model"; do
@@ -33,7 +42,6 @@ jobs:
               echo "Testing parameter $file"
               # use schema from current branch
               # (as this branch might have introduced schema changes)
-              CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
               sed -i "" "s/main/$CURRENT_BRANCH/" "$file"
               cat "$file"
               simtools-validate-file-using-schema \

--- a/.github/workflows/parameter-file-validation.yml
+++ b/.github/workflows/parameter-file-validation.yml
@@ -46,7 +46,7 @@ jobs:
               --file_name "$file" \
               --log_level DEBUG
             done < tmp
-            rm tmp
+            rm -f tmp
           done
 
       - name: Metadata validation.
@@ -61,5 +61,5 @@ jobs:
               --validate_metadata \
               --log_level DEBUG
             done < tmp
-            rm tmp
+            rm -f tmp
           done

--- a/.github/workflows/parameter-file-validation.yml
+++ b/.github/workflows/parameter-file-validation.yml
@@ -42,7 +42,7 @@ jobs:
               echo "Testing parameter $file"
               # use schema from current branch
               # (as this branch might have introduced schema changes)
-              sed -i "" "s/main/$CURRENT_BRANCH/" "$file"
+              sed -i -e "s/main/$CURRENT_BRANCH/" "$file"
               cat "$file"
               simtools-validate-file-using-schema \
               --file_name "$file" \

--- a/.github/workflows/parameter-file-validation.yml
+++ b/.github/workflows/parameter-file-validation.yml
@@ -31,7 +31,6 @@ jobs:
           else
             echo "CURRENT_BRANCH=${GITHUB_REF#refs/heads/}" >> "$GITHUB_ENV"
           fi
-          echo "Current branch $CURRENT_BRANCH"
 
       - name: Parameter file validation.
         run: |
@@ -43,7 +42,6 @@ jobs:
               # use schema from current branch
               # (as this branch might have introduced schema changes)
               sed -i -e "s/main/$CURRENT_BRANCH/" "$file"
-              cat "$file"
               simtools-validate-file-using-schema \
               --file_name "$file" \
               --log_level DEBUG

--- a/.github/workflows/parameter-file-validation.yml
+++ b/.github/workflows/parameter-file-validation.yml
@@ -31,6 +31,11 @@ jobs:
             while IFS= read -r file
             do
               echo "Testing parameter $file"
+              # use schema from current branch
+              # (as this branch might have introduced schema changes)
+              CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+              sed -i "" "s/main/$CURRENT_BRANCH/" "$file"
+              cat "$file"
               simtools-validate-file-using-schema \
               --file_name "$file" \
               --log_level DEBUG

--- a/.github/workflows/parameter-file-validation.yml
+++ b/.github/workflows/parameter-file-validation.yml
@@ -1,0 +1,54 @@
+---
+name: Parameter file validation
+# Validate parameter files against their schema.
+# This workflow is to support developers.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  schema-validation:
+    runs-on: ubuntu-latest
+    container: ghcr.io/gammasim/simtools-prod:latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install findutils
+        run: |
+          microdnf install -y findutils
+
+      - name: Parameter file validation.
+        run: |
+          for model in "verified_model" "validated_model"; do
+            find "$model" -name '*.json' > tmp
+            while IFS= read -r file
+            do
+              echo "Testing parameter $file"
+              simtools-validate-file-using-schema \
+              --file_name "$file" \
+              --log_level DEBUG
+            done < tmp
+            rm tmp
+          done
+
+      - name: Metadata validation.
+        run: |
+          for model in "verified_model" "validated_model"; do
+            find "$model" -name '*.json' > tmp
+            while IFS= read -r file
+            do
+              echo "Testing parameter $file"
+              simtools-validate-file-using-schema \
+              --file_name "$file" \
+              --validate_metadata \
+              --log_level DEBUG
+            done < tmp
+            rm tmp
+          done

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,22 @@
+name: "Pull request checklist"
+on:
+  pull_request_target:
+    types:
+      - ready_for_review
+jobs:
+  pull_request_info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checklist
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: show_checklist
+          message: |
+            Checklist for pull request review.
+
+            - [ ] Review METADATA:PRODUCT:DESCRIPTION field in parameter files (this should be equivalent to a commit message)

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -23,6 +23,11 @@ jobs:
         run: |
           microdnf install -y findutils
 
+      - name: linter
+        run: |
+          pip install yamllint
+          yamllint schema/*.yml
+
       - name: Validate schema files.
         run: |
           for file in schema/*.yml; do

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,8 +1,6 @@
 ---
-name: Parameter file validation
+name: Schema file validation
 # Validate schema files against their metaschema.
-# Validate parameter files against their schema.
-# This workflow is to support developers.
 
 on:
   push:
@@ -27,30 +25,9 @@ jobs:
 
       - name: Validate schema files.
         run: |
-          for file in $(find schema -name "*.yml"); do
+          for file in schema/*.yml; do
             echo "Testing schema $file"
             simtools-validate-file-using-schema \
-              --file_name $file \
-              --log_level DEBUG
-          done
-
-      - name: Validate parameter files.
-        run: |
-          for file in $(find verified_model -name "*.json"); do
-            PARAM=$(basename $file .json)
-            echo "Testing parameter $file"
-            simtools-validate-file-using-schema \
-            --file_name $file \
-            --log_level DEBUG
-          done
-
-      - name: Validate metadata in parameter files.
-        run: |
-          for file in $(find verified_model -name "*.json"); do
-            PARAM=$(basename $file .json)
-            echo "Testing metadata for parameter $file"
-            simtools-validate-file-using-schema \
-              --file_name $file \
-              --validate_metadata \
+              --file_name "$file" \
               --log_level DEBUG
           done

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,6 +1,7 @@
 ---
 name: Schema file validation
 # Validate schema files against their metaschema.
+# This workflow is to support developers.
 
 on:
   push:
@@ -23,7 +24,7 @@ jobs:
         run: |
           microdnf install -y findutils
 
-      - name: linter
+      - name: Linter
         run: |
           pip install yamllint
           yamllint schema/*.yml

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Linter
         run: |
           pip install yamllint
-          yamllint schema/*.yml
+          yamllint -d "{rules: {line-length: {max: 150}}}" schema/*.yml
 
       - name: Validate schema files.
         run: |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Reference implementation of CTA simulation model parameters consisting of:
 
 The verified model consists of a set of json or yaml files verified to follow the corresponding schema file. The simtools application `simtools-validate-file-using-schema` is used for the verification.
 
-Validated parameters are used successfully in [simtools](https://github.com/gammasim/simtools) (this needs to be documented). 
+Validated parameters are used successfully in [simtools](https://github.com/gammasim/simtools) (this needs to be documented).
 Parameters which are validated can be submitted to the simulation model database.
 
 ### Implementation
@@ -18,14 +18,13 @@ Parameters which are validated can be submitted to the simulation model database
 A typical model files includes:
 
 ```yaml
-value:
-type:
-unit:
-version:
-metadata: { }
+Value:
+Type:
+units:
+Metadata: { }
 ```
 
-The `value` field contains the actual value of the parameter or points towards a data file (e.g., an astropy table in ecsv format).
+The `Value` field contains the actual value of the parameter or points towards a data file (e.g., an astropy table in ecsv format).
 (The inclusion of the unit and type in the model file is still under discussion since it is technically part of the schema and does not have to be included here explicitly.)
 
 ### Subdivision of model files for telescope types and sites
@@ -51,7 +50,7 @@ The following example is for a single parameter description.
 title: Schema for num_gains model parameter
 version: 0.1.0
 base_schema: simpipe-schema
-base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
+base_schema_url:https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
 base_schema_version: 0.1.0
 name: num_gains
 description: Number of different gains the input signal gets digitized.
@@ -155,4 +154,11 @@ Describes the source of the data or parameter (e.g., *Calibration*)
 ### Simulation software description
 
 Describes the simulation software (e.g., *sim_telarray* or *corsika*) the parameter is used for.
+For some parameters, different names are used in the different software packages (e.g. `corsika_observation_level` is `OBSLEVEL` in CORSIKA).
+In this case, the 'parameter_name' field documents this mapping:
 
+```yaml
+simulation_software:
+  - name: corsika
+    parameter_name: OBSLEV
+```

--- a/schema/altitude.schema.yml
+++ b/schema/altitude.schema.yml
@@ -3,7 +3,8 @@
 title: Schema for altitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_url: >
+  https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
 meta_schema_version: 0.1.0
 name: altitude
 description: |-

--- a/schema/altitude.schema.yml
+++ b/schema/altitude.schema.yml
@@ -3,8 +3,7 @@
 title: Schema for altitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: >
-  https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
 meta_schema_version: 0.1.0
 name: altitude
 description: |-


### PR DESCRIPTION
Improve CI.

Functional changes:

- use current branch for parameter file validation (this is important: this means that any changes to schema files applied in the current branch are used in the validation; otherwise these workflows would fail)
- add yaml linter to schema validation
- add a 'sticky pull request' comment - meaning that when pressing 'pull request ready for review', a checklist appears for the reviewer (easier to remember than adding instructions to the README file; see [this example](https://github.com/GernotMaier/Sandkasten/pull/5))

Code improvements from discussions with @orelgueta and linters:

- separate schema and parameter file validation
- make shellcheck happier (especially the fragile [for loops](https://www.shellcheck.net/wiki/SC2044)